### PR TITLE
Replace column names - full regex.replace support

### DIFF
--- a/PerseusPluginLib/Rearrange/RenameColumnsRegexp.cs
+++ b/PerseusPluginLib/Rearrange/RenameColumnsRegexp.cs
@@ -33,12 +33,13 @@ namespace PerseusPluginLib.Rearrange{
 
 		public void ProcessData(IMatrixData mdata, Parameters param, ref IMatrixData[] supplTables,
 			ref IDocumentData[] documents, ProcessInfo processInfo){
-			string regexStr = param.GetParam<string>("Regular expression").Value;
-			Regex regex = new Regex(regexStr);
+			string patternStr = param.GetParam<string>("Pattern").Value;
+			string replacementStr = param.GetParam<string>("Replacement").Value;
+			Regex regex = new Regex(patternStr);
 			for (int i = 0; i < mdata.ColumnCount; i++){
-				string newName = regex.Match(mdata.ColumnNames[i]).Groups[1].ToString();
+				string newName = regex.Replace(mdata.ColumnNames[i], replacementStr);
 				if (string.IsNullOrEmpty(newName)){
-					processInfo.ErrString = "Applying parse rule to '" + mdata.ColumnNames[i] + "' results in an empty string.";
+					processInfo.ErrString = $"Applying replacement rule to '{mdata.ColumnNames[i]}' results in an empty string.";
 					return;
 				}
 				mdata.ColumnNames[i] = newName;
@@ -48,12 +49,10 @@ namespace PerseusPluginLib.Rearrange{
 		public Parameters GetParameters(IMatrixData mdata, ref string errorString){
 			return
 				new Parameters(new Parameter[]{
-					new StringParam("Regular expression"){
-						Help =
-							"The regular expression that determines how the new column names are created from the old " +
-							"column names. As an example if you want to transform 'Ratio H/L Normalized Something' " +
-							"into 'Something' the suitable regular expression is 'Ratio H/L Normalized (.*)'"
-					}
+                    new StringParam("Pattern") { Default = "(*.)",
+                        Help = "The regular expression used to match the column names. See help for examples"},
+                    new StringParam("Replacement"){ Default = "$1",
+                        Help = "The replacement pattern. See help for examples"},
 				});
 		}
 	}

--- a/PerseusPluginLibTest/PerseusPluginLibTest.csproj
+++ b/PerseusPluginLibTest/PerseusPluginLibTest.csproj
@@ -41,6 +41,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PerseusLib, Version=1.5.1.6, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DLLs\PerseusLib.dll</HintPath>
@@ -56,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rearrange\ProcessTextColumnsTest.cs" />
+    <Compile Include="Rearrange\RenameColumnsRegexpTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PerseusApi\PerseusApi.csproj">
@@ -69,6 +74,9 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/PerseusPluginLibTest/Rearrange/RenameColumnsRegexpTest.cs
+++ b/PerseusPluginLibTest/Rearrange/RenameColumnsRegexpTest.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PerseusApi.Document;
+using PerseusApi.Matrix;
+using PerseusPluginLib.Rearrange;
+
+namespace PerseusPluginLibTest.Rearrange
+{
+    [TestClass]
+    public class RenameColumnsRegexpTest
+    {
+        [TestMethod]
+        public void TestWikiExample()
+        {
+            var renamer = new RenameColumnsRegexp();
+            var matrix = new Moq.Mock<IMatrixData>();
+            var colnames = new List<string>() {"column 1", "column 2", "column 3"};
+            matrix.Setup(m => m.ColumnCount).Returns(colnames.Count);
+            matrix.Setup(m => m.ColumnNames).Returns(colnames);
+            string err = "";
+            var param = renamer.GetParameters(matrix.Object, ref err);
+            param.GetParam<string>("Regular expression").Value = "column (.*)";
+
+            IMatrixData[] supplTables = null;
+            IDocumentData[] documents = null;
+            renamer.ProcessData(matrix.Object, param, ref supplTables, ref documents, null);
+
+            CollectionAssert.AreEqual(new List<string> {"1", "2", "3"}, colnames);
+        }
+    }
+}

--- a/PerseusPluginLibTest/Rearrange/RenameColumnsRegexpTest.cs
+++ b/PerseusPluginLibTest/Rearrange/RenameColumnsRegexpTest.cs
@@ -9,23 +9,58 @@ namespace PerseusPluginLibTest.Rearrange
     [TestClass]
     public class RenameColumnsRegexpTest
     {
+        /// <summary>
+        /// Test the wiki example
+        /// </summary>
         [TestMethod]
         public void TestWikiExample()
         {
+            var colnames = new List<string>() {"column 1", "column 2", "column 3"};
+            Rename(colnames, "column (.*)", "$1");
+            CollectionAssert.AreEqual(new List<string> {"1", "2", "3"}, colnames);
+        }
+
+        /// <summary>
+        /// Test switching order
+        /// </summary>
+        [TestMethod]
+        public void TestSwitchOrder()
+        {
+            var colnames = new List<string>() {"column 1", "column 2", "column 3"};
+            Rename(colnames, "(?<first>.*) (?<second>.*)", "${second} ${first}");
+            CollectionAssert.AreEqual(new List<string> {"1 column", "2 column", "3 column"}, colnames);
+        }
+        
+
+        [TestMethod]
+        public void TestReplacement()
+        {
+            var colnames = new List<string>() {"column 1", "column 2", "column 3"};
+            Rename(colnames, "(column) (.*)", "$1SPACE$2");
+            CollectionAssert.AreEqual(new List<string> {"columnSPACE1", "columnSPACE2", "columnSPACE3"}, colnames);
+        }
+
+        /// <summary>
+        /// renaming helper method for mocking IMatrixData
+        /// </summary>
+        /// <param name="colnames"></param>
+        /// <param name="pattern"></param>
+        /// <param name="replacement"></param>
+        private static void Rename(List<string> colnames, string pattern, string replacement)
+        {
             var renamer = new RenameColumnsRegexp();
             var matrix = new Moq.Mock<IMatrixData>();
-            var colnames = new List<string>() {"column 1", "column 2", "column 3"};
             matrix.Setup(m => m.ColumnCount).Returns(colnames.Count);
             matrix.Setup(m => m.ColumnNames).Returns(colnames);
             string err = "";
             var param = renamer.GetParameters(matrix.Object, ref err);
-            param.GetParam<string>("Regular expression").Value = "column (.*)";
+            param.GetParam<string>("Pattern").Value = pattern;
+            param.GetParam<string>("Replacement").Value = replacement;
 
             IMatrixData[] supplTables = null;
             IDocumentData[] documents = null;
             renamer.ProcessData(matrix.Object, param, ref supplTables, ref documents, null);
-
-            CollectionAssert.AreEqual(new List<string> {"1", "2", "3"}, colnames);
         }
+
     }
 }

--- a/PerseusPluginLibTest/packages.config
+++ b/PerseusPluginLibTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
currently renaming columns allows for cutting the names only
    
    replace("column 1", "column (.*)")
        ==> "1"

by providing both, the pattern and the replacement one can support any kind of renaming by exposing `regex.replace` instead of `regex.match`

    replace("column 1 / column 2", "column (.) / column (.)", "ratio $1, $2")
        ==> "ratio 1, 2"

I could provide some examples and references for the help page
http://coxdocs.org/doku.php?id=perseus:user:activities:MatrixProcessing:Rearrange:RenameColumnsRegexp

### Testing
I added some unit tests and a dependency on the `Moq` package for testing.